### PR TITLE
POC for node mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gin: Genetic Improvement in No Time
-SB
+SB 
 This is the repository for the academic research paper "Genetic Improvement in No Time", submitted to the GI 2017 workshop at GECCO 2017. [Please see this preprint of the paper](doc/gin.pdf).
 
 Gin is a [Genetic Improvement](https://en.wikipedia.org/wiki/Genetic_improvement_(computer_science)) (GI) tool. Genetic Improvement is the application of [Genetic Programming](https://en.wikipedia.org/wiki/Genetic_programming) and other metaheuristics to existing software, to improve it in some way. In its initial incarnation, Gin was designed to reduce the execution time of Java code by modifying source files whilst preserving functionality as embodied by a set of JUnit tests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gin: Genetic Improvement in No Time
-
+SB
 This is the repository for the academic research paper "Genetic Improvement in No Time", submitted to the GI 2017 workshop at GECCO 2017. [Please see this preprint of the paper](doc/gin.pdf).
 
 Gin is a [Genetic Improvement](https://en.wikipedia.org/wiki/Genetic_improvement_(computer_science)) (GI) tool. Genetic Improvement is the application of [Genetic Programming](https://en.wikipedia.org/wiki/Genetic_programming) and other metaheuristics to existing software, to improve it in some way. In its initial incarnation, Gin was designed to reduce the execution time of Java code by modifying source files whilst preserving functionality as embodied by a set of JUnit tests.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Gin: Genetic Improvement in No Time
-SB 
+
 This is the repository for the academic research paper "Genetic Improvement in No Time", submitted to the GI 2017 workshop at GECCO 2017. [Please see this preprint of the paper](doc/gin.pdf).
 
 Gin is a [Genetic Improvement](https://en.wikipedia.org/wiki/Genetic_improvement_(computer_science)) (GI) tool. Genetic Improvement is the application of [Genetic Programming](https://en.wikipedia.org/wiki/Genetic_programming) and other metaheuristics to existing software, to improve it in some way. In its initial incarnation, Gin was designed to reduce the execution time of Java code by modifying source files whilst preserving functionality as embodied by a set of JUnit tests.

--- a/examples/Triangle2.java
+++ b/examples/Triangle2.java
@@ -1,0 +1,51 @@
+public class Triangle2 {
+
+    public enum TriangleType {
+        INVALID, SCALENE, EQUALATERAL, ISOCELES
+    }
+
+    public static TriangleType classifyTriangle(int a, int b, int c) {
+
+        delay();
+        
+        if (a > b) {
+            int tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        if (a > c) {
+            int tmp = a;
+            a = c;
+            c = tmp;
+        }
+
+        if (b > c) {
+            int tmp = b;
+            b = c;
+            c = tmp;
+        }
+
+        if (a + b <= c) {
+            return TriangleType.INVALID;
+        } else if (a == b && b == c) {
+            return TriangleType.EQUALATERAL;
+        } else if (a == b || b == c) {
+            return TriangleType.ISOCELES;
+        } else {
+            return TriangleType.SCALENE;
+        }
+
+    }
+
+    private static void delay() {
+    	if (System.currentTimeMillis() > 0) {
+	    	try {
+	            Thread.sleep(100);
+	        } catch (InterruptedException e) {
+	
+	        }
+    	}
+    }
+
+}

--- a/examples/Triangle2.java
+++ b/examples/Triangle2.java
@@ -40,10 +40,10 @@ public class Triangle2 {
 
     private static void delay() {
     	if (System.currentTimeMillis() > 0) {
-	    	try {
+	        try {
 	            Thread.sleep(100);
 	        } catch (InterruptedException e) {
-	
+	            // do nothing
 	        }
     	}
     }

--- a/examples/Triangle2Test.java
+++ b/examples/Triangle2Test.java
@@ -2,9 +2,9 @@ import static org.junit.Assert.assertEquals;
 
 public class Triangle2Test {
 
-    private void checkClassification(int[][] triangles, ExampleTriangleProgram2.TriangleType expectedResult) {
+    private void checkClassification(int[][] triangles, Triangle2.TriangleType expectedResult) {
         for (int[] triangle: triangles) {
-            ExampleTriangleProgram2.TriangleType triangleType = ExampleTriangleProgram2.classifyTriangle(triangle[0], triangle[1], triangle[2]);
+        	Triangle2.TriangleType triangleType = Triangle2.classifyTriangle(triangle[0], triangle[1], triangle[2]);
             assertEquals(expectedResult, triangleType);
         }
     }
@@ -12,25 +12,25 @@ public class Triangle2Test {
     @org.junit.Test
     public void testInvalidTriangles() throws Exception {
         int[][] invalidTriangles = {{1, 2, 9}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}, {100, 80, 10000}};
-        checkClassification(invalidTriangles, ExampleTriangleProgram2.TriangleType.INVALID);
+        checkClassification(invalidTriangles, Triangle2.TriangleType.INVALID);
     }
 
     @org.junit.Test
     public void testEqualateralTriangles() throws Exception {
         int[][] equalateralTriangles = {{1, 1, 1}, {100, 100, 100}, {99, 99, 99}};
-        checkClassification(equalateralTriangles, ExampleTriangleProgram2.TriangleType.EQUALATERAL);
+        checkClassification(equalateralTriangles, Triangle2.TriangleType.EQUALATERAL);
     }
 
     @org.junit.Test
     public void testIsocelesTriangles() throws Exception {
         int[][] isocelesTriangles = {{100, 90, 90}, {1000, 900, 900}, {3,2,2}, {30,16,16}};
-        checkClassification(isocelesTriangles, ExampleTriangleProgram2.TriangleType.ISOCELES);
+        checkClassification(isocelesTriangles, Triangle2.TriangleType.ISOCELES);
     }
 
     @org.junit.Test
     public void testScaleneTriangles() throws Exception {
         int[][] scaleneTriangles = {{5, 4, 3}, {1000, 900, 101}, {3,20,21}, {999, 501, 600}};
-        checkClassification(scaleneTriangles, ExampleTriangleProgram2.TriangleType.SCALENE);
+        checkClassification(scaleneTriangles, Triangle2.TriangleType.SCALENE);
     }
 
 }

--- a/examples/Triangle2Test.java
+++ b/examples/Triangle2Test.java
@@ -1,0 +1,36 @@
+import static org.junit.Assert.assertEquals;
+
+public class Triangle2Test {
+
+    private void checkClassification(int[][] triangles, ExampleTriangleProgram2.TriangleType expectedResult) {
+        for (int[] triangle: triangles) {
+            ExampleTriangleProgram2.TriangleType triangleType = ExampleTriangleProgram2.classifyTriangle(triangle[0], triangle[1], triangle[2]);
+            assertEquals(expectedResult, triangleType);
+        }
+    }
+
+    @org.junit.Test
+    public void testInvalidTriangles() throws Exception {
+        int[][] invalidTriangles = {{1, 2, 9}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}, {100, 80, 10000}};
+        checkClassification(invalidTriangles, ExampleTriangleProgram2.TriangleType.INVALID);
+    }
+
+    @org.junit.Test
+    public void testEqualateralTriangles() throws Exception {
+        int[][] equalateralTriangles = {{1, 1, 1}, {100, 100, 100}, {99, 99, 99}};
+        checkClassification(equalateralTriangles, ExampleTriangleProgram2.TriangleType.EQUALATERAL);
+    }
+
+    @org.junit.Test
+    public void testIsocelesTriangles() throws Exception {
+        int[][] isocelesTriangles = {{100, 90, 90}, {1000, 900, 900}, {3,2,2}, {30,16,16}};
+        checkClassification(isocelesTriangles, ExampleTriangleProgram2.TriangleType.ISOCELES);
+    }
+
+    @org.junit.Test
+    public void testScaleneTriangles() throws Exception {
+        int[][] scaleneTriangles = {{5, 4, 3}, {1000, 900, 101}, {3,20,21}, {999, 501, 600}};
+        checkClassification(scaleneTriangles, ExampleTriangleProgram2.TriangleType.SCALENE);
+    }
+
+}

--- a/src/main/java/gin/LocalSearch.java
+++ b/src/main/java/gin/LocalSearch.java
@@ -126,7 +126,7 @@ public class LocalSearch {
         } else {
             neighbour.addRandomEdit(rng);
         }
-
+        
         return neighbour;
 
     }

--- a/src/main/java/gin/Patch.java
+++ b/src/main/java/gin/Patch.java
@@ -1,23 +1,24 @@
 package gin;
 
-import com.github.javaparser.ast.CompilationUnit;
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.stmt.BlockStmt;
-import com.github.javaparser.ast.stmt.Statement;
-import com.github.javaparser.ast.visitor.ModifierVisitor;
-import gin.edit.CopyStatement;
-import gin.edit.DeleteStatement;
-import gin.edit.Edit;
-import gin.edit.MoveStatement;
-import org.apache.commons.io.FileUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+
+import org.apache.commons.io.FileUtils;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.Statement;
+
+import gin.edit.CopyStatement;
+import gin.edit.DeleteStatement;
+import gin.edit.Edit;
+import gin.edit.ModifyNode;
+import gin.edit.MoveStatement;
+import gin.edit.modifynode.LogicalOperatorReplacementFactory;
 
 /**
  * Represents a patch, a potential set of changes to a sourcefile.
@@ -120,6 +121,13 @@ public class Patch {
                 Insertion insertion = new Insertion(source, targetStatementIndex, parent);
                 insertions.add(insertion);
 
+            } else if (edit instanceof ModifyNode) {
+            	// each of these has an internal list of nodes and an index
+            	// the change will not affect the structure so we can
+            	// make the patch without a ConcurrentModificationException
+            	// Just supply the new source, and ask them to make the change.
+            	@SuppressWarnings("unused") // currently ignore the result
+            	boolean result = ((ModifyNode)edit).apply(patchedCompilationUnit);
             }
 
         }
@@ -148,16 +156,20 @@ public class Patch {
 
     private Edit randomEdit(Random rng) {
 
+    	// separate factories needed for different modifyNode operators
+    	LogicalOperatorReplacementFactory lorFactory = new LogicalOperatorReplacementFactory(sourceFile.getCompilationUnit());
+    	// ...
+    	
         Edit edit = null;
 
-        int editType = rng.nextInt(3);
+        int editType = rng.nextInt(4);
 
         switch (editType) {
-            case (0):
+            case (0): // delete statement
                 int statementToDelete = rng.nextInt(sourceFile.getStatementCount());
                 edit = new DeleteStatement(statementToDelete);
                 break;
-            case (1):
+            case (1): // copy statement
                 int statementToCopy = rng.nextInt(sourceFile.getStatementCount());
                 int insertBlock = rng.nextInt(sourceFile.getNumberOfBlocks());
                 int numberOfInsertionPoints = sourceFile.getNumberOfInsertionPointsInBlock(insertBlock);
@@ -169,7 +181,7 @@ public class Patch {
                 }
                 edit = new CopyStatement(statementToCopy, insertBlock, insertStatement);
                 break;
-            case (2):
+            case (2): // move statement
                 int statementToMove = rng.nextInt(sourceFile.getStatementCount());
                 int moveBlock = rng.nextInt(sourceFile.getNumberOfBlocks());
                 int numberOfDestinationPoints = sourceFile.getNumberOfInsertionPointsInBlock(moveBlock);
@@ -181,6 +193,14 @@ public class Patch {
                 }
                 edit = new MoveStatement(statementToMove, moveBlock, movePoint);
                 break;
+            case (3): // modify statement
+            	// could do some checking for type here by calling ModifyNodeFactory.applicability().appliesTo()
+            	// just to be sure there are some nodes that can be changed by a particular operator!
+            
+            	// will also need a random choice between different modifications...
+            	// see https://github.com/gintool/gin/issues/13#issuecomment-342489660
+            	edit = lorFactory.newModifier(rng);
+            	break;
         }
 
         return edit;

--- a/src/main/java/gin/edit/ModifyNode.java
+++ b/src/main/java/gin/edit/ModifyNode.java
@@ -1,0 +1,40 @@
+package gin.edit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+
+public abstract class ModifyNode extends Edit {
+	/**the refers to the applicable nodes in the corresponding factory!*/
+    public final int sourceNodeIndex;
+
+    public final List<Node> sourceNodes;
+    
+    public final ModifyNodeFactory factory;
+    
+    /**
+     * @param sourceNodes is the list of possible nodes for modification; these won't be
+	 * 	      modified, just used for reference
+     * @param r is provided to choose a node to modify, and choose a replacement*/
+    public ModifyNode(List<Node> sourceNodes, ModifyNodeFactory factory, Random r) {
+        this.sourceNodes = Collections.unmodifiableList(sourceNodes);
+        this.sourceNodeIndex = r.nextInt(sourceNodes.size());
+        this.factory = factory;
+    }
+    
+    /**
+     * Apply this patch to the supplied compilation unit.
+     * Assumes that the CU is identical in structure to the one used
+     * to create this edit
+     * @return true if modification was successful
+     */
+    public abstract boolean apply(CompilationUnit cu);
+    
+    @Override
+    public String toString() {
+        return "MODIFY " + sourceNodeIndex + " ( " + this.getClass().getName() + " )";
+    }
+}

--- a/src/main/java/gin/edit/ModifyNodeFactory.java
+++ b/src/main/java/gin/edit/ModifyNodeFactory.java
@@ -1,0 +1,50 @@
+package gin.edit;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+
+/**
+ * Makes ModifyNode instances
+ */
+public abstract class ModifyNodeFactory {
+	private List<Node> sourceNodes;
+	
+	public ModifyNodeFactory(CompilationUnit cu) {
+		this.sourceNodes = this.appliesToNodes(cu);
+	}
+	
+	public List<Node> getSourceNodes() {
+		return sourceNodes;
+	}
+	
+	public abstract ModifyNode newModifier(Random rng);
+		
+    /**
+     * @return a collection of Class objects identifying the statement/expression etc. classes that this applies to.
+     * Typically you'd return something like Collections.singleton(Statement.class);
+     * This can be ignored but might serve to be useful if we want a more intelligent mutation at some point
+     * (hopefully this would mean less broken code) 
+     */
+	public abstract Collection<Class<? extends Node>> appliesTo();
+	
+    /**
+     * @return collection of nodes from a given source file that the modification applies to
+     */
+    public final List<Node> appliesToNodes(CompilationUnit cu) {
+    	Set<Node> nodes = new LinkedHashSet<Node>(); // LinkedHashSet preserves order - keeps operation deterministic
+    	
+    	for (Class<? extends Node> clazz : appliesTo()) {
+    		nodes.addAll(cu.getChildNodesByType(clazz));
+    	}
+    	
+    	return Collections.unmodifiableList(new ArrayList<Node>(nodes));
+    }
+}

--- a/src/main/java/gin/edit/modifynode/LogicalOperatorReplacement.java
+++ b/src/main/java/gin/edit/modifynode/LogicalOperatorReplacement.java
@@ -1,0 +1,94 @@
+package gin.edit.modifynode;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BinaryExpr.Operator;
+
+import gin.edit.ModifyNode;
+
+public class LogicalOperatorReplacement extends ModifyNode {
+	private final Operator source;
+	private final Operator replacement;
+	
+	// the following list is not perfect! needs refinement.
+	private static final Map<Operator, List<Operator>> REPLACEMENTS = new LinkedHashMap<>();
+	static {
+		REPLACEMENTS.put(Operator.AND, Arrays.asList(Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.BINARY_AND, Arrays.asList(Operator.AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.BINARY_OR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.OR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.XOR));
+		REPLACEMENTS.put(Operator.XOR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR));
+		
+		REPLACEMENTS.put(Operator.GREATER, Arrays.asList(Operator.EQUALS, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.GREATER_EQUALS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.LESS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.LESS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.GREATER_EQUALS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.LESS_EQUALS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.GREATER_EQUALS, Operator.LESS));
+				
+		REPLACEMENTS.put(Operator.DIVIDE, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.LEFT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.MINUS, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.MULTIPLY, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.PLUS, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.REMAINDER, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.SIGNED_RIGHT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.UNSIGNED_RIGHT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT));
+		
+		REPLACEMENTS.put(Operator.EQUALS, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.BINARY_OR, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.NOT_EQUALS, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.BINARY_OR, Operator.EQUALS, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS, Operator.OR, Operator.XOR));
+	}
+	
+	/**
+	 * Naming follows MuJava convention
+	 * LOR
+	 * 
+	 * @param sourceNodes is the list of possible nodes for modification; these won't be
+	 * 	      modified, just used for reference
+	 * @param r is needed to choose a node and a suitable replacement 
+	 *        (keeps this detail out of Patch class)
+	 */
+	public LogicalOperatorReplacement(List<Node> sourceNodes, LogicalOperatorReplacementFactory factory, Random r) {
+		super(sourceNodes, factory, r);
+		
+		BinaryExpr sourceNode = (BinaryExpr)(this.sourceNodes.get(sourceNodeIndex));
+		
+		this.source = sourceNode.getOperator();
+		this.replacement = chooseRandomReplacement(source, r);
+	}
+	
+	@Override
+	public boolean apply(CompilationUnit cu) {
+		// first, get the list of nodes from the new cu
+		List<Node> nodes = this.factory.appliesToNodes(cu);
+		
+		Node node = nodes.get(sourceNodeIndex);
+		
+		((BinaryExpr)node).setOperator(replacement);
+		
+		return true;
+	}
+	
+	private static Operator chooseRandomReplacement(Operator original, Random r) {
+		Operator replacement;
+		/*
+		do {
+			replacement = Operator.values()[r.nextInt(Operator.values().length)];
+		} while (replacement.equals(original));
+		*/
+		List<Operator> l = REPLACEMENTS.get(original);
+		replacement = l.get(r.nextInt(l.size()));
+		
+		return replacement;
+	}
+	
+	@Override
+	public String toString() {
+		return super.toString() + " [" + source + " -> " + replacement + "]";
+	}
+}

--- a/src/main/java/gin/edit/modifynode/LogicalOperatorReplacement.java
+++ b/src/main/java/gin/edit/modifynode/LogicalOperatorReplacement.java
@@ -17,7 +17,7 @@ public class LogicalOperatorReplacement extends ModifyNode {
 	private final Operator source;
 	private final Operator replacement;
 	
-	// the following list is not perfect! needs refinement.
+	// the following list is not perfect! needs refinement, if not total replacement with a better way to do this
 	private static final Map<Operator, List<Operator>> REPLACEMENTS = new LinkedHashMap<>();
 	static {
 		REPLACEMENTS.put(Operator.AND, Arrays.asList(Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));

--- a/src/main/java/gin/edit/modifynode/LogicalOperatorReplacementFactory.java
+++ b/src/main/java/gin/edit/modifynode/LogicalOperatorReplacementFactory.java
@@ -1,0 +1,30 @@
+package gin.edit.modifynode;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Random;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.BinaryExpr;
+
+import gin.edit.ModifyNode;
+import gin.edit.ModifyNodeFactory;
+
+public class LogicalOperatorReplacementFactory extends ModifyNodeFactory {
+	public LogicalOperatorReplacementFactory(CompilationUnit cu) {
+		super(cu);
+	}
+	
+	@Override
+	public ModifyNode newModifier(Random rng) {
+		return new LogicalOperatorReplacement(getSourceNodes(), this, rng);
+	}
+	
+	
+	
+	@Override
+	public Collection<Class<? extends Node>> appliesTo() {
+		return Collections.singleton(BinaryExpr.class);
+	}
+}

--- a/src/test/resources/ExampleTriangleProgram2.java
+++ b/src/test/resources/ExampleTriangleProgram2.java
@@ -1,0 +1,49 @@
+public class ExampleTriangleProgram2 {
+
+    public enum TriangleType {
+        INVALID, SCALENE, EQUALATERAL, ISOCELES
+    }
+
+    public static TriangleType classifyTriangle(int a, int b, int c) {
+
+        if (a > b) {
+            int tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        if (a > c) {
+            int tmp = a;
+            a = c;
+            c = tmp;
+        }
+
+        if (b > c) {
+            int tmp = b;
+            b = c;
+            c = tmp;
+        }
+
+        if (a + b <= c) {
+            return TriangleType.INVALID;
+        } else if (a == b && b == c) {
+            return TriangleType.EQUALATERAL;
+        } else if (a == b || b == c) {
+            return TriangleType.ISOCELES;
+        } else {
+            return TriangleType.SCALENE;
+        }
+
+    }
+
+    private static void delay() {
+    	if (System.currentTimeMillis() > 0) {
+	    	try {
+	            Thread.sleep(100);
+	        } catch (InterruptedException e) {
+	
+	        }
+    	}
+    }
+
+}

--- a/src/test/resources/ExampleTriangleProgram2Test.java
+++ b/src/test/resources/ExampleTriangleProgram2Test.java
@@ -1,0 +1,36 @@
+import static org.junit.Assert.assertEquals;
+
+public class ExampleTriangleProgram2Test {
+
+    private void checkClassification(int[][] triangles, ExampleTriangleProgram2.TriangleType expectedResult) {
+        for (int[] triangle: triangles) {
+            ExampleTriangleProgram2.TriangleType triangleType = ExampleTriangleProgram2.classifyTriangle(triangle[0], triangle[1], triangle[2]);
+            assertEquals(expectedResult, triangleType);
+        }
+    }
+
+    @org.junit.Test
+    public void testInvalidTriangles() throws Exception {
+        int[][] invalidTriangles = {{1, 2, 9}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}, {100, 80, 10000}};
+        checkClassification(invalidTriangles, ExampleTriangleProgram2.TriangleType.INVALID);
+    }
+
+    @org.junit.Test
+    public void testEqualateralTriangles() throws Exception {
+        int[][] equalateralTriangles = {{1, 1, 1}, {100, 100, 100}, {99, 99, 99}};
+        checkClassification(equalateralTriangles, ExampleTriangleProgram2.TriangleType.EQUALATERAL);
+    }
+
+    @org.junit.Test
+    public void testIsocelesTriangles() throws Exception {
+        int[][] isocelesTriangles = {{100, 90, 90}, {1000, 900, 900}, {3,2,2}, {30,16,16}};
+        checkClassification(isocelesTriangles, ExampleTriangleProgram2.TriangleType.ISOCELES);
+    }
+
+    @org.junit.Test
+    public void testScaleneTriangles() throws Exception {
+        int[][] scaleneTriangles = {{5, 4, 3}, {1000, 900, 101}, {3,20,21}, {999, 501, 600}};
+        checkClassification(scaleneTriangles, ExampleTriangleProgram2.TriangleType.SCALENE);
+    }
+
+}


### PR DESCRIPTION
Addresses #13 

Rather than statements, the idea is to modify types of nodes in the source tree, so that we can include statements, expressions, types and so on too. In this proof of concept we have the following:

A new abstract subclass of gin.edit.Edit, gin.edit.ModifyNode. ModifyNode maintains its own list of nodes that are of the relevant type in the original source, as well as the index of the particular node to be modified.

A new abstract class gin.edit.ModifyNodeFactory, whose job it is to make ModifyNode objects, provides a list of applicable node types for ModifyNode, and can filter the nodes in a CompilationUnit to be provided as candidates for modification.

A concrete class gin.edit.modifynode.LogicalOperatorReplacement, based on the LOR operator in MuJava. This applies to any BinaryStatement nodes, and will swap the operator with others of the same category (e.g. arithmetic operators are one category, comparisons are another, boolean operators are another).

A concrete class gin.edit.modifynode.LogicalOperatorReplacementFactory, which makes instances of the above and provides "BinaryStatement" as its only applicable node type.

Patch.java - added necessary code to make new random LogicalOperatorReplacement instances and apply them - this is quite brief as most of the work is in the factory.

I went with the factory method, so the factory can take care of things like working out whether the relevant nodes exist before we've made any operators of a particular type. It will also take care of setting up the node lists as a appropriate to avoid doing it every time a new operator instance is made.

I've provided a Triangle2 test program in examples/, where the delay is wrapped in a if(currentTime > 0) block that *should* always run - one fix is still to delete the delay, but another is to swap the > for another comparison that will usually evaluate to false.