### PR TITLE
Added Edits for Unary Operators

### DIFF
--- a/examples/Triangle3.java
+++ b/examples/Triangle3.java
@@ -1,0 +1,54 @@
+public class Triangle3 {
+
+    public enum TriangleType {
+        INVALID, SCALENE, EQUALATERAL, ISOCELES
+    }
+
+    public static TriangleType classifyTriangle(int a, int b, int c) {
+
+        delay();
+        
+        if (a > b) {
+            int tmp = a;
+            a = b;
+            b = tmp;
+        }
+
+        if (a > c) {
+            int tmp = a;
+            a = c;
+            c = tmp;
+        }
+
+        if (b > c) {
+            int tmp = b;
+            b = c;
+            c = tmp;
+        }
+
+        if (a + b <= c) {
+            return TriangleType.INVALID;
+        } else if (a == b && b == c) {
+            return TriangleType.EQUALATERAL;
+        } else if (a == b || b == c) {
+            return TriangleType.ISOCELES;
+        } else {
+            return TriangleType.SCALENE;
+        }
+
+    }
+
+    private static void delay() {
+    	int i = 1;
+    	i++;
+    	
+    	if (i == 2) {
+	        try {
+	            Thread.sleep(100);
+	        } catch (InterruptedException e) {
+	            // do nothing
+	        }
+    	}
+    }
+
+}

--- a/examples/Triangle3Test.java
+++ b/examples/Triangle3Test.java
@@ -1,0 +1,36 @@
+import static org.junit.Assert.assertEquals;
+
+public class Triangle3Test {
+
+    private void checkClassification(int[][] triangles, Triangle3.TriangleType expectedResult) {
+        for (int[] triangle: triangles) {
+        	Triangle3.TriangleType triangleType = Triangle3.classifyTriangle(triangle[0], triangle[1], triangle[2]);
+            assertEquals(expectedResult, triangleType);
+        }
+    }
+
+    @org.junit.Test
+    public void testInvalidTriangles() throws Exception {
+        int[][] invalidTriangles = {{1, 2, 9}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}, {100, 80, 10000}};
+        checkClassification(invalidTriangles, Triangle3.TriangleType.INVALID);
+    }
+
+    @org.junit.Test
+    public void testEqualateralTriangles() throws Exception {
+        int[][] equalateralTriangles = {{1, 1, 1}, {100, 100, 100}, {99, 99, 99}};
+        checkClassification(equalateralTriangles, Triangle3.TriangleType.EQUALATERAL);
+    }
+
+    @org.junit.Test
+    public void testIsocelesTriangles() throws Exception {
+        int[][] isocelesTriangles = {{100, 90, 90}, {1000, 900, 900}, {3,2,2}, {30,16,16}};
+        checkClassification(isocelesTriangles, Triangle3.TriangleType.ISOCELES);
+    }
+
+    @org.junit.Test
+    public void testScaleneTriangles() throws Exception {
+        int[][] scaleneTriangles = {{5, 4, 3}, {1000, 900, 101}, {3,20,21}, {999, 501, 600}};
+        checkClassification(scaleneTriangles, Triangle3.TriangleType.SCALENE);
+    }
+
+}

--- a/src/main/java/gin/Patch.java
+++ b/src/main/java/gin/Patch.java
@@ -19,6 +19,8 @@ import gin.edit.Edit;
 import gin.edit.ModifyNode;
 import gin.edit.MoveStatement;
 import gin.edit.modifynode.LogicalOperatorReplacementFactory;
+import gin.edit.modifynode.UnaryOperatorReplacement;
+import gin.edit.modifynode.UnaryOperatorReplacementFactory;
 
 /**
  * Represents a patch, a potential set of changes to a sourcefile.
@@ -158,11 +160,12 @@ public class Patch {
 
     	// separate factories needed for different modifyNode operators
     	LogicalOperatorReplacementFactory lorFactory = new LogicalOperatorReplacementFactory(sourceFile.getCompilationUnit());
+    	UnaryOperatorReplacementFactory uorFactory = new UnaryOperatorReplacementFactory(sourceFile.getCompilationUnit());
     	// ...
     	
         Edit edit = null;
 
-        int editType = rng.nextInt(4);
+        int editType = rng.nextInt(5);
 
         switch (editType) {
             case (0): // delete statement
@@ -193,7 +196,7 @@ public class Patch {
                 }
                 edit = new MoveStatement(statementToMove, moveBlock, movePoint);
                 break;
-            case (3): // modify statement
+            case (3): // modify statement - binary operators (was originally just logical operators)
             	// could do some checking for type here by calling ModifyNodeFactory.applicability().appliesTo()
             	// just to be sure there are some nodes that can be changed by a particular operator!
             
@@ -201,6 +204,10 @@ public class Patch {
             	// see https://github.com/gintool/gin/issues/13#issuecomment-342489660
             	edit = lorFactory.newModifier(rng);
             	break;
+            case (4): // modify statement - unary operators
+            	edit = uorFactory.newModifier(rng);
+            	break;
+            	
         }
 
         return edit;

--- a/src/main/java/gin/edit/ModifyNode.java
+++ b/src/main/java/gin/edit/ModifyNode.java
@@ -8,19 +8,22 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 
 public abstract class ModifyNode extends Edit {
-	/**the refers to the applicable nodes in the corresponding factory!*/
+	/**the node to be modified*/
     public final int sourceNodeIndex;
 
+    /**the applicable nodes in the corresponding factory*/
     public final List<Node> sourceNodes;
     
     public final ModifyNodeFactory factory;
     
     /**
+     * Note: this will assume that there will be some applicable nodes!
+     * @throws IllegalArgumentException if sourceNodes is empty
      * @param sourceNodes is the list of possible nodes for modification; these won't be
 	 * 	      modified, just used for reference
      * @param r is provided to choose a node to modify, and choose a replacement*/
     public ModifyNode(List<Node> sourceNodes, ModifyNodeFactory factory, Random r) {
-        this.sourceNodes = Collections.unmodifiableList(sourceNodes);
+    	this.sourceNodes = Collections.unmodifiableList(sourceNodes);
         this.sourceNodeIndex = r.nextInt(sourceNodes.size());
         this.factory = factory;
     }

--- a/src/main/java/gin/edit/modifynode/UnaryOperatorReplacement.java
+++ b/src/main/java/gin/edit/modifynode/UnaryOperatorReplacement.java
@@ -1,0 +1,95 @@
+package gin.edit.modifynode;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BinaryExpr.Operator;
+import com.github.javaparser.ast.expr.UnaryExpr;
+
+import gin.edit.ModifyNode;
+
+public class UnaryOperatorReplacement extends ModifyNode {
+	private final Operator source;
+	private final Operator replacement;
+	
+	// the following list is not perfect! needs refinement, if not total replacement with a better way to do this
+	private static final Map<Operator, List<Operator>> REPLACEMENTS = new LinkedHashMap<>();
+	static {
+		REPLACEMENTS.put(Operator.AND, Arrays.asList(Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.BINARY_AND, Arrays.asList(Operator.AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.BINARY_OR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.OR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.XOR));
+		REPLACEMENTS.put(Operator.XOR, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.EQUALS, Operator.BINARY_OR, Operator.NOT_EQUALS, Operator.OR));
+		
+		REPLACEMENTS.put(Operator.GREATER, Arrays.asList(Operator.EQUALS, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.GREATER_EQUALS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.LESS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.LESS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.GREATER_EQUALS, Operator.LESS_EQUALS));
+		REPLACEMENTS.put(Operator.LESS_EQUALS, Arrays.asList(Operator.EQUALS, Operator.GREATER, Operator.GREATER_EQUALS, Operator.LESS));
+				
+		REPLACEMENTS.put(Operator.DIVIDE, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.LEFT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.MINUS, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.MULTIPLY, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.PLUS, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.REMAINDER, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.SIGNED_RIGHT_SHIFT, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.SIGNED_RIGHT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.UNSIGNED_RIGHT_SHIFT));
+		REPLACEMENTS.put(Operator.UNSIGNED_RIGHT_SHIFT, Arrays.asList(Operator.DIVIDE, Operator.LEFT_SHIFT, Operator.MINUS, Operator.MULTIPLY, Operator.PLUS, Operator.REMAINDER, Operator.SIGNED_RIGHT_SHIFT));
+		
+		REPLACEMENTS.put(Operator.EQUALS, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.BINARY_OR, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS, Operator.NOT_EQUALS, Operator.OR, Operator.XOR));
+		REPLACEMENTS.put(Operator.NOT_EQUALS, Arrays.asList(Operator.AND, Operator.BINARY_AND, Operator.BINARY_OR, Operator.EQUALS, Operator.GREATER_EQUALS, Operator.LESS, Operator.LESS_EQUALS, Operator.OR, Operator.XOR));
+	}
+	
+	/**
+	 * Naming follows MuJava convention
+	 * LOR
+	 * 
+	 * @param sourceNodes is the list of possible nodes for modification; these won't be
+	 * 	      modified, just used for reference
+	 * @param r is needed to choose a node and a suitable replacement 
+	 *        (keeps this detail out of Patch class)
+	 */
+	public UnaryOperatorReplacement(List<Node> sourceNodes, LogicalOperatorReplacementFactory factory, Random r) {
+		super(sourceNodes, factory, r);
+		
+		BinaryExpr sourceNode = (BinaryExpr)(this.sourceNodes.get(sourceNodeIndex));
+		
+		this.source = sourceNode.getOperator();
+		this.replacement = chooseRandomReplacement(source, r);
+	}
+	
+	@Override
+	public boolean apply(CompilationUnit cu) {
+		// first, get the list of nodes from the new cu
+		List<Node> nodes = this.factory.appliesToNodes(cu);
+		
+		Node node = nodes.get(sourceNodeIndex);
+		
+		((BinaryExpr)node).setOperator(replacement);
+		
+		return true;
+	}
+	
+	private static Operator chooseRandomReplacement(Operator original, Random r) {
+		Operator replacement;
+		/*
+		do {
+			replacement = Operator.values()[r.nextInt(Operator.values().length)];
+		} while (replacement.equals(original));
+		*/
+		List<Operator> l = REPLACEMENTS.get(original);
+		replacement = l.get(r.nextInt(l.size()));
+		
+		return replacement;
+	}
+	
+	@Override
+	public String toString() {
+		return super.toString() + " [" + source + " -> " + replacement + "]";
+	}
+}

--- a/src/main/java/gin/edit/modifynode/UnaryOperatorReplacementFactory.java
+++ b/src/main/java/gin/edit/modifynode/UnaryOperatorReplacementFactory.java
@@ -1,0 +1,30 @@
+package gin.edit.modifynode;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Random;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.UnaryExpr;
+
+import gin.edit.ModifyNode;
+import gin.edit.ModifyNodeFactory;
+
+public class UnaryOperatorReplacementFactory extends ModifyNodeFactory {
+	public UnaryOperatorReplacementFactory(CompilationUnit cu) {
+		super(cu);
+	}
+	
+	@Override
+	public ModifyNode newModifier(Random rng) {
+		return new UnaryOperatorReplacement(getSourceNodes(), this, rng);
+	}
+	
+	
+	
+	@Override
+	public Collection<Class<? extends Node>> appliesTo() {
+		return Collections.singleton(UnaryExpr.class);
+	}
+}


### PR DESCRIPTION
Added a new subclass of ModifyNode: UnaryOperatorReplacement. This will allow edits that replace one unary operator with another, within these two groups:

logical complement (~); bitwise complement (!); minus (- indicates negative number); plus (+ positive number)

postfix increment (++); postfix decrement (--); prefix increment (++); prefix decrement (--);

Also, edits for modifying nodes won't be added unless there are some nodes they can be applied to.