### PR TITLE
Improved ClassLoader documentation and changed how modified classes are stored

### DIFF
--- a/src/main/java/gin/test/CacheClassLoader.java
+++ b/src/main/java/gin/test/CacheClassLoader.java
@@ -13,8 +13,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Intercept classloading of JUnitBridge, and provide access to class from the target system
- * Also allow overlaying of the modified classes.
+/**
+ * Intercept classloading of JUnitBridge, and provide access to class from the
+ * target system Also allow overlaying of the modified classes.F
  */
 public class CacheClassLoader extends URLClassLoader {
 
@@ -24,17 +25,33 @@ public class CacheClassLoader extends URLClassLoader {
 
     private URL[] providedClassPath;
 
+    /**
+     * Constructs a ClassLoader with the system classpath and the elements given
+     * as input.
+     *
+     * @param classPaths classpath elements to append to the system's classpath.
+     */
     public CacheClassLoader(URL[] classPaths) {
         super(addSystemClassPath(classPaths), null);
         providedClassPath = classPaths;
     }
 
+    /**
+     * Constructs a ClassLoader with the system classpath and the elements given
+     * as input. The input should be a full classpath with elements separated by
+     * a colon.
+     *
+     * @param classpath a : separated classpath to append to the system's
+     * classpath.
+     */
     public CacheClassLoader(String classpath) {
         this(classPathToURLs(classpath));
     }
 
-
-    // If the class can't be found using parents (I don't have any) then drops back here.
+    /**
+     * If the class can't be found using parents (I don't have any) then drops
+     * back here.
+     */
     @Override
     protected Class<?> findClass(String name) throws ClassNotFoundException {
 
@@ -61,12 +78,21 @@ public class CacheClassLoader extends URLClassLoader {
 
     }
 
-    // Store the results of compilation from the InMemoryCompiler
+    /**
+     * Store the results of compilation from the InMemoryCompiler.
+     *
+     * @param className the fully qualified class name.
+     * @param compiledCode the compiled code for the given class.
+     */
     public void setCustomCompiledCode(String className, CompiledCode compiledCode) {
         this.customCompiledCode.put(className, compiledCode);
     }
 
-    // Utility method to convert a : separated classpath into an array of URLs
+    /**
+     * Utility method to convert a : separated classpath into an array of URLs.
+     *
+     * @return the set of converted classpath elements.
+     */
     private static final URL[] classPathToURLs(String classPath) {
 
         if (classPath == null) {
@@ -76,7 +102,7 @@ public class CacheClassLoader extends URLClassLoader {
         String[] dirs = classPath.split(File.pathSeparator);
         List<URL> urls = new ArrayList<>();
 
-        for (String dir: dirs) {
+        for (String dir : dirs) {
             try {
                 URL url = new File(dir).toURI().toURL();
                 urls.add(url);
@@ -92,6 +118,14 @@ public class CacheClassLoader extends URLClassLoader {
 
     }
 
+    /**
+     * Add multiple URLs as classpath elements to the system classpath and
+     * returns the union.
+     *
+     * @param projectClasspath classpath elements.
+     * @return new array containing the system classpath and the elements given
+     * as input.
+     */
     public static final URL[] addSystemClassPath(URL[] projectClasspath) {
 
         String classPath = System.getProperty("java.class.path");
@@ -101,7 +135,7 @@ public class CacheClassLoader extends URLClassLoader {
         URL[] urls = new URL[paths.length];
         int counter = 0;
 
-        for (String path : paths){
+        for (String path : paths) {
             try {
                 urls[counter] = new File(path).toURI().toURL();
                 counter++;
@@ -118,9 +152,14 @@ public class CacheClassLoader extends URLClassLoader {
 
     }
 
+    /**
+     * Gets the provided classpath elements provided in the constructor;
+     *
+     * @return the set of classpath elements given as input to the constructor
+     * of the object.
+     */
     public URL[] getProvidedClassPath() {
         return providedClassPath;
     }
-
 
 }

--- a/src/main/java/gin/test/CacheClassLoader.java
+++ b/src/main/java/gin/test/CacheClassLoader.java
@@ -1,7 +1,6 @@
 package gin.test;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.mdkt.compiler.CompiledCode;
 import org.pmw.tinylog.Logger;
 
 import java.io.File;
@@ -21,7 +20,7 @@ public class CacheClassLoader extends URLClassLoader {
 
     private static final String BRIDGE_CLASS_NAME = gin.test.JUnitBridge.class.getName();
 
-    protected Map<String, CompiledCode> customCompiledCode = new HashMap<>();
+    protected Map<String, byte[]> customCompiledCode = new HashMap<>();
 
     private URL[] providedClassPath;
 
@@ -62,8 +61,7 @@ public class CacheClassLoader extends URLClassLoader {
 
         // Modified class? Return the modified code.
         if (customCompiledCode.containsKey(name)) {
-            CompiledCode cc = customCompiledCode.get(name);
-            byte[] byteCode = cc.getByteCode();
+            byte[] byteCode = customCompiledCode.get(name);
             return defineClass(name, byteCode, 0, byteCode.length);
         }
 
@@ -84,7 +82,7 @@ public class CacheClassLoader extends URLClassLoader {
      * @param className the fully qualified class name.
      * @param compiledCode the compiled code for the given class.
      */
-    public void setCustomCompiledCode(String className, CompiledCode compiledCode) {
+    public void setCustomCompiledCode(String className, byte[] compiledCode) {
         this.customCompiledCode.put(className, compiledCode);
     }
 

--- a/src/main/java/gin/test/InternalTestRunner.java
+++ b/src/main/java/gin/test/InternalTestRunner.java
@@ -68,7 +68,7 @@ public class InternalTestRunner extends TestRunner {
         // Add to class loader and run tests
         List<UnitTestResult> results = null;
         if (compiledOK) {
-            classLoader.setCustomCompiledCode(this.getClassName(), code);
+            classLoader.setCustomCompiledCode(this.getClassName(), code.getByteCode());
             results = runTests(reps, classLoader);
         }
 

--- a/src/main/java/gin/util/DeleteEnumerator.java
+++ b/src/main/java/gin/util/DeleteEnumerator.java
@@ -58,7 +58,7 @@ public class DeleteEnumerator extends Sampler {
         Logger.info("Random seed for method selection: "+ randomSeed);
     }
 
-    protected void sampleMethods() {
+    protected void sampleMethodsHook() {
 
         Random rng = new JDKRandomBridge(RandomSource.MT, Long.valueOf(randomSeed));
 

--- a/src/main/java/gin/util/EmptyPatchTester.java
+++ b/src/main/java/gin/util/EmptyPatchTester.java
@@ -36,7 +36,7 @@ public class EmptyPatchTester extends Sampler{
         super(projectDir, methodFile);
     }
 
-    protected void sampleMethods() {
+    protected void sampleMethodsHook() {
         
         writeHeader();
 

--- a/src/main/java/gin/util/GP.java
+++ b/src/main/java/gin/util/GP.java
@@ -43,7 +43,7 @@ public abstract class GP extends Sampler {
     protected Random mutationRng;
     protected Random individualRng;
     
-       public GP(String[] args) {
+    public GP(String[] args) {
         super(args);
         Args.parseOrExit(this, args);
         printAdditionalArguments();
@@ -69,8 +69,7 @@ public abstract class GP extends Sampler {
     }
 
     // Implementation of the abstract method
-    protected void sampleMethods() {
-
+    protected void sampleMethodsHook() {
         writeNewHeader();
 
         for (TargetMethod method : methodData) {
@@ -121,9 +120,8 @@ public abstract class GP extends Sampler {
                         , "FitnessImprovement"
                         };
         try {
-            CSVWriter writer = new CSVWriter(new FileWriter(outputFile));
-            writer.writeNext(entry);
-            writer.close();
+            outputFileWriter = new CSVWriter(new FileWriter(outputFile));
+            outputFileWriter.writeNext(entry);
         } catch (IOException e) {
             Logger.error(e, "Exception writing results to the output file: " + outputFile.getAbsolutePath());
             Logger.trace(e);
@@ -140,15 +138,7 @@ public abstract class GP extends Sampler {
                         , Long.toString(fitness)
                         , Long.toString(improvement)
                         };
-        try {
-            CSVWriter writer = new CSVWriter(new FileWriter(outputFile, true));
-            writer.writeNext(entry);
-            writer.close();
-        } catch (IOException e) {
-            Logger.error(e, "Exception writing results to the output file: " + outputFile.getAbsolutePath());
-            Logger.trace(e);
-            System.exit(-1);
-        }
+        outputFileWriter.writeNext(entry);
     }
 
 }

--- a/src/main/java/gin/util/RandomSampler.java
+++ b/src/main/java/gin/util/RandomSampler.java
@@ -1,11 +1,7 @@
 package gin.util;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.ArrayList;
 import java.util.Random;
-import java.util.Set;
 
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
@@ -17,8 +13,6 @@ import org.pmw.tinylog.Logger;
 import gin.Patch;
 import gin.SourceFile;
 import gin.edit.Edit.EditType;
-import gin.test.UnitTest;
-import gin.test.UnitTestResult;
 import gin.test.UnitTestResultSet;
 
 
@@ -70,7 +64,7 @@ public class RandomSampler extends Sampler {
         Logger.info("Random seed for edit type selection: "+ patchSeed);
     }
 
-   protected void sampleMethods() {
+   protected void sampleMethodsHook() {
 
         Random mrng = new JDKRandomBridge(RandomSource.MT, Long.valueOf(methodSeed)); 
         

--- a/src/main/java/gin/util/Trace.java
+++ b/src/main/java/gin/util/Trace.java
@@ -93,7 +93,7 @@ public class Trace {
         // \tsun.font.CFont.createNativeFont(CFont.java:Unknown line)
         // We're extracting: the trace number, the name of the method, the line number ('Unknown line' special case).
 
-        String regex = "^TRACE (\\d+):\\n^\\t(.*)\\(.*:(.*)\\)$";
+        String regex = "^TRACE (\\d+):(?:\\r\\n|\\r|\\n)^\\t(.*)\\(.*:(.*)\\)$";
         Pattern p = Pattern.compile(regex, Pattern.MULTILINE);
         Matcher m = p.matcher(hprof);
 

--- a/src/test/java/gin/test/CompilerTest.java
+++ b/src/test/java/gin/test/CompilerTest.java
@@ -32,7 +32,7 @@ public class CompilerTest {
         assertTrue(code != null);
 
         CacheClassLoader loader = new CacheClassLoader(classPath);
-        loader.setCustomCompiledCode(className, code);
+        loader.setCustomCompiledCode(className, code.getByteCode());
         Class compiledClass = loader.findClass("SimpleExample");
 
         assertNotNull(compiledClass);

--- a/src/test/java/gin/test/TestRunnerTest.java
+++ b/src/test/java/gin/test/TestRunnerTest.java
@@ -232,7 +232,7 @@ public class TestRunnerTest {
         CompiledCode code = Compiler.compile("mypackage.NewExample", srcCode, TestConfiguration.EXAMPLE_DIR_NAME);
 
         CacheClassLoader loader = new CacheClassLoader(TestConfiguration.EXAMPLE_DIR_NAME);
-        loader.setCustomCompiledCode("mypackage.NewExample", code);
+        loader.setCustomCompiledCode("mypackage.NewExample", code.getByteCode());
 
         try {
             Class example = loader.findClass("mypackage.NewExample");

--- a/src/test/java/gin/util/DeleteEnumeratorTest.java
+++ b/src/test/java/gin/util/DeleteEnumeratorTest.java
@@ -16,7 +16,6 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class DeleteEnumeratorTest {
     File methodFile = new File(packageDir, "profiler_results.csv");
     File outputFile = new File(packageDir, "delete_enumerator_results.csv");
 
-    DeleteEnumerator enumerator; 
+    DeleteEnumerator enumerator;
 
     @Before
     public void setUp() throws Exception {
@@ -59,14 +58,15 @@ public class DeleteEnumeratorTest {
             File exampleTestFile = new File(resourcesDir, "ExampleTest.java");
             File exampleBaseFile = new File(resourcesDir, "ExampleBase.java");
             Iterable<? extends JavaFileObject> compilationUnit = fm.getJavaFileObjectsFromFiles(Arrays.asList(
-                        exampleFile
-                        , exampleTestFile
-                        , exampleBaseFile
-                        ));
-            JavaCompiler.CompilationTask task =
-                compiler.getTask(null, fm, null, options, null, compilationUnit);
-            if (!task.call())
+                    exampleFile,
+                     exampleTestFile,
+                     exampleBaseFile
+            ));
+            JavaCompiler.CompilationTask task
+                    = compiler.getTask(null, fm, null, options, null, compilationUnit);
+            if (!task.call()) {
                 throw new AssertionError("compilation failed");
+            }
         }
 
     }
@@ -75,102 +75,101 @@ public class DeleteEnumeratorTest {
     public void testApplyPatchesToMethod() throws Exception {
 
         enumerator.sampleMethods();
+        try (FileReader fileReader = new FileReader(outputFile)) {
 
-        CSVReader reader = new CSVReader(new FileReader(outputFile));
-        List<String[]> lines = reader.readAll();
-        String[] header = lines.get(0);
-        String[] result = lines.get(1);
+            CSVReader reader = new CSVReader(fileReader);
+            List<String[]> lines = reader.readAll();
+            String[] header = lines.get(0);
+            String[] result = lines.get(1);
 
-        int validIndex = Arrays.asList(header).indexOf("PatchValid");
-        int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
-        int testIndex = Arrays.asList(header).indexOf("TestPassed");
+            int validIndex = Arrays.asList(header).indexOf("PatchValid");
+            int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
+            int testIndex = Arrays.asList(header).indexOf("TestPassed");
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        result = lines.get(2);
+            result = lines.get(2);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        result = lines.get(3);
+            result = lines.get(3);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
 
-        result = lines.get(4);
+            result = lines.get(4);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        result = lines.get(5);
+            result = lines.get(5);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        result = lines.get(6);
+            result = lines.get(6);
 
-        // Start removing statements
-        // 9:{
-        //     int result = 100;
-        //     result = 20;
-        //     result = 10;
-        //     return result;
-        // }
-        // 10:int result = 100;
-        // 16:result = 20;
-        // 21:result = 10;
-        // 26:return result;
+            // Start removing statements
+            // 9:{
+            //     int result = 100;
+            //     result = 20;
+            //     result = 10;
+            //     return result;
+            // }
+            // 10:int result = 100;
+            // 16:result = 20;
+            // 21:result = 10;
+            // 26:return result;
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            result = lines.get(7);
 
-        result = lines.get(7);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            result = lines.get(8);
 
-        result = lines.get(8);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            result = lines.get(9);
 
-        result = lines.get(9);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
+            result = lines.get(10);
 
-        result = lines.get(10);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
+            result = lines.get(11);
 
-        result = lines.get(11);
-
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+        }
         Files.deleteIfExists(outputFile.toPath());  // tidy up
-
     }
 
     @After
     public void tearDown() throws Exception {
-            File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
-            resourcesDir = new File(resourcesDir, "mypackage");
-            Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
+        File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
+        resourcesDir = new File(resourcesDir, "mypackage");
+        Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
     }
 }

--- a/src/test/java/gin/util/EmptyPatchTesterTest.java
+++ b/src/test/java/gin/util/EmptyPatchTesterTest.java
@@ -212,6 +212,7 @@ public class EmptyPatchTesterTest {
         sampler.writeHeader();
 
         assertTrue(outputFile.exists());
+        sampler.close();
         Files.deleteIfExists(outputFile.toPath());
         FileUtils.deleteDirectory(innerDir);
         FileUtils.deleteDirectory(topDir);

--- a/src/test/java/gin/util/EmptyPatchTesterTest.java
+++ b/src/test/java/gin/util/EmptyPatchTesterTest.java
@@ -16,7 +16,6 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.After;
@@ -53,14 +52,15 @@ public class EmptyPatchTesterTest {
             File exampleTestFile = new File(resourcesDir, "ExampleTest.java");
             File exampleBaseFile = new File(resourcesDir, "ExampleBase.java");
             Iterable<? extends JavaFileObject> compilationUnit = fm.getJavaFileObjectsFromFiles(Arrays.asList(
-                        exampleFile
-                        , exampleTestFile
-                        , exampleBaseFile
-                        ));
-            JavaCompiler.CompilationTask task =
-                compiler.getTask(null, fm, null, options, null, compilationUnit);
-            if (!task.call())
+                    exampleFile,
+                    exampleTestFile,
+                    exampleBaseFile
+            ));
+            JavaCompiler.CompilationTask task
+                    = compiler.getTask(null, fm, null, options, null, compilationUnit);
+            if (!task.call()) {
                 throw new AssertionError("compilation failed");
+            }
         }
 
     }
@@ -76,34 +76,34 @@ public class EmptyPatchTesterTest {
         sampler.setUp();
         sampler.sampleMethods();
 
-        CSVReader reader = new CSVReader(new FileReader(outputFile));
-        List<String[]> lines = reader.readAll();
+        try (CSVReader reader = new CSVReader(new FileReader(outputFile))) {
+            List<String[]> lines = reader.readAll();
 
-        assertEquals(lines.size(), 4);
+            assertEquals(lines.size(), 4);
 
-        String[] header = lines.get(0);
-        String[] result = lines.get(1);
+            String[] header = lines.get(0);
+            String[] result = lines.get(1);
 
-        int validIndex = Arrays.asList(header).indexOf("PatchValid");
-        int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
-        int testIndex = Arrays.asList(header).indexOf("TestPassed");
+            int validIndex = Arrays.asList(header).indexOf("PatchValid");
+            int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
+            int testIndex = Arrays.asList(header).indexOf("TestPassed");
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(2);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(3);
+            result = lines.get(2);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+
+            result = lines.get(3);
+
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+        }
         Files.deleteIfExists(outputFile.toPath());  // tidy up
 
     }
@@ -121,34 +121,34 @@ public class EmptyPatchTesterTest {
 
         sampler.sampleMethods();
 
-        CSVReader reader = new CSVReader(new FileReader(outputFile));
-        List<String[]> lines = reader.readAll();
+        try (CSVReader reader = new CSVReader(new FileReader(outputFile))) {
+            List<String[]> lines = reader.readAll();
 
-        assertEquals(lines.size(), 4);
+            assertEquals(lines.size(), 4);
 
-        String[] header = lines.get(0);
-        String[] result = lines.get(1);
+            String[] header = lines.get(0);
+            String[] result = lines.get(1);
 
-        int validIndex = Arrays.asList(header).indexOf("PatchValid");
-        int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
-        int testIndex = Arrays.asList(header).indexOf("TestPassed");
+            int validIndex = Arrays.asList(header).indexOf("PatchValid");
+            int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
+            int testIndex = Arrays.asList(header).indexOf("TestPassed");
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(2);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(3);
+            result = lines.get(2);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+
+            result = lines.get(3);
+
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+        }
         Files.deleteIfExists(outputFile.toPath());  // tidy up
 
     }
@@ -166,34 +166,34 @@ public class EmptyPatchTesterTest {
 
         sampler.sampleMethods();
 
-        CSVReader reader = new CSVReader(new FileReader(outputFile));
-        List<String[]> lines = reader.readAll();
+        try (CSVReader reader = new CSVReader(new FileReader(outputFile))) {
+            List<String[]> lines = reader.readAll();
 
-        assertEquals(lines.size(), 4);
+            assertEquals(lines.size(), 4);
 
-        String[] header = lines.get(0);
-        String[] result = lines.get(1);
+            String[] header = lines.get(0);
+            String[] result = lines.get(1);
 
-        int validIndex = Arrays.asList(header).indexOf("PatchValid");
-        int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
-        int testIndex = Arrays.asList(header).indexOf("TestPassed");
+            int validIndex = Arrays.asList(header).indexOf("PatchValid");
+            int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
+            int testIndex = Arrays.asList(header).indexOf("TestPassed");
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(2);
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
-        result = lines.get(3);
+            result = lines.get(2);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("true", result[compileIndex]);
-        assertEquals("true", result[testIndex]);
-        
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+
+            result = lines.get(3);
+
+            assertEquals("true", result[validIndex]);
+            assertEquals("true", result[compileIndex]);
+            assertEquals("true", result[testIndex]);
+        }
         Files.deleteIfExists(outputFile.toPath());  // tidy up
 
     }
@@ -220,10 +220,10 @@ public class EmptyPatchTesterTest {
 
     @After
     public void tearDown() throws Exception {
-            File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
-            resourcesDir = new File(resourcesDir, "mypackage");
-            Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
+        File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
+        resourcesDir = new File(resourcesDir, "mypackage");
+        Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
     }
 }

--- a/src/test/java/gin/util/ProfilerTest.java
+++ b/src/test/java/gin/util/ProfilerTest.java
@@ -33,9 +33,10 @@ public class ProfilerTest {
         tests.add(test);
         //profiler.profileTestSuite(tests); //Use this to generate the hprof
 
-        File scratchFile = new File("scratch"+ File.separator +"testEnumProfiling.txt");
+        File scratchFile = new File("scratch" + File.separator + "testEnumProfiling.txt");
+        FileWriter fileWriter = new FileWriter(scratchFile.getAbsolutePath());
         Configurator.defaultConfig()
-                .writer(new FileWriter(scratchFile.getAbsolutePath()))
+                .writer(fileWriter)
                 .level(Level.WARNING)
                 .activate();
 
@@ -43,14 +44,15 @@ public class ProfilerTest {
 
         String logMessages = FileUtils.readFileToString(scratchFile, Charset.defaultCharset());
 
-        String missingMessage =  "WARNING: Excluding method as class in main tree but method not found: " +
-                "example.ExampleEnum.values";
+        String missingMessage = "WARNING: Excluding method as class in main tree but method not found: "
+                + "example.ExampleEnum.values";
 
         String likelyEnumMessage = "WARNING: This is likely because the method relates to an enum type.";
 
         assertTrue(logMessages.contains(missingMessage));
         assertTrue(logMessages.contains(likelyEnumMessage));
 
+        fileWriter.close();
         Files.deleteIfExists(scratchFile.toPath());  // tidy up
         Files.deleteIfExists(new File("scratch").toPath());  // tidy up
     }

--- a/src/test/java/gin/util/RandomSamplerTest.java
+++ b/src/test/java/gin/util/RandomSamplerTest.java
@@ -16,7 +16,6 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 
-
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
@@ -32,7 +31,7 @@ public class RandomSamplerTest {
     File methodFile = new File(packageDir, "profiler_results.csv");
     File outputFile = new File(packageDir, "random_sampler_results.csv");
 
-    RandomSampler sampler; 
+    RandomSampler sampler;
 
     @Before
     public void setUp() throws Exception {
@@ -60,14 +59,15 @@ public class RandomSamplerTest {
             File exampleTestFile = new File(resourcesDir, "ExampleTest.java");
             File exampleBaseFile = new File(resourcesDir, "ExampleBase.java");
             Iterable<? extends JavaFileObject> compilationUnit = fm.getJavaFileObjectsFromFiles(Arrays.asList(
-                        exampleFile
-                        , exampleTestFile
-                        , exampleBaseFile
-                        ));
-            JavaCompiler.CompilationTask task =
-                compiler.getTask(null, fm, null, options, null, compilationUnit);
-            if (!task.call())
+                    exampleFile,
+                     exampleTestFile,
+                     exampleBaseFile
+            ));
+            JavaCompiler.CompilationTask task
+                    = compiler.getTask(null, fm, null, options, null, compilationUnit);
+            if (!task.call()) {
                 throw new AssertionError("compilation failed");
+            }
         }
 
     }
@@ -77,97 +77,97 @@ public class RandomSamplerTest {
 
         sampler.sampleMethods();
 
-        CSVReader reader = new CSVReader(new FileReader(outputFile));
-        List<String[]> lines = reader.readAll();
+        try (CSVReader reader = new CSVReader(new FileReader(outputFile))) {
+            List<String[]> lines = reader.readAll();
 
-        assertEquals(lines.size(), 11);
+            assertEquals(lines.size(), 11);
 
-        String[] header = lines.get(0);
-        String[] result = lines.get(1);
+            String[] header = lines.get(0);
+            String[] result = lines.get(1);
 
-        int validIndex = Arrays.asList(header).indexOf("PatchValid");
-        int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
-        int testIndex = Arrays.asList(header).indexOf("TestPassed");
-        int patchSize = Arrays.asList(header).indexOf("PatchSize");
+            int validIndex = Arrays.asList(header).indexOf("PatchValid");
+            int compileIndex = Arrays.asList(header).indexOf("PatchCompiled");
+            int testIndex = Arrays.asList(header).indexOf("TestPassed");
+            int patchSize = Arrays.asList(header).indexOf("PatchSize");
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(2);
+            result = lines.get(2);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(3);
+            result = lines.get(3);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(4);
+            result = lines.get(4);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(5);
+            result = lines.get(5);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(6);
+            result = lines.get(6);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(7);
+            result = lines.get(7);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(8);
+            result = lines.get(8);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(9);
+            result = lines.get(9);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
 
-        result = lines.get(10);
+            result = lines.get(10);
 
-        assertEquals("true", result[validIndex]);
-        assertEquals("false", result[compileIndex]);
-        assertEquals("false", result[testIndex]);
-        assertEquals("2", result[patchSize]);
-
+            assertEquals("true", result[validIndex]);
+            assertEquals("false", result[compileIndex]);
+            assertEquals("false", result[testIndex]);
+            assertEquals("2", result[patchSize]);
+        }
         Files.deleteIfExists(outputFile.toPath());  // tidy up
 
     }
 
     @After
     public void tearDown() throws Exception {
-            File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
-            resourcesDir = new File(resourcesDir, "mypackage");
-            Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
-            Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
+        File resourcesDir = new File(TestConfiguration.EXAMPLE_DIR_NAME);
+        resourcesDir = new File(resourcesDir, "mypackage");
+        Files.deleteIfExists(new File(resourcesDir, "Example.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleBase.class").toPath());
+        Files.deleteIfExists(new File(resourcesDir, "ExampleTest.class").toPath());
     }
 }


### PR DESCRIPTION
My modifications can be broken down into three:

1. I changed some documentation of CachedClassLoader. Basically I replaced // with /** * */ so that it is properly indexed as Javadoc. I also added more info on parameters and return types;
2. I changed the way modified classes are stored in the ClassLoader. Before it was using a CompiledClass object, but now it uses a byte[] object. The reasoning behind this modification is to decouple ClassLoader from CompiledClass. If we obtain the bytecode of a class by other means other than compiling it with the respective API, then we can easily integrate the code. Furthermore, it improves the cohesion of CachedClassLoader, because now it does not need to obtain the bytecode, just load it;
3. I changed some test cases in order to close input and output streams before excluding files. It was causing tests to fail on Windows, because Windows won't allow files to be excluded while they are being read/written by an open stream.

I have also auto-formatted the code of the classes I modified, thus the diff contains some white/trailing space removal, indentation fixes, and unused imports removal.