### PR TITLE
Changed "testData" from List to Set.

### DIFF
--- a/src/main/java/gin/util/Sampler.java
+++ b/src/main/java/gin/util/Sampler.java
@@ -26,6 +26,10 @@ import gin.test.InternalTestRunner;
 import gin.test.UnitTest;
 import gin.test.UnitTestResult;
 import gin.test.UnitTestResultSet;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Handy class for mutating and running tests on mutated code.
@@ -105,7 +109,7 @@ public abstract class Sampler {
 
     protected List<TargetMethod> methodData = new ArrayList<>();
     
-    protected List<UnitTest> testData = new ArrayList<>();
+    protected Set<UnitTest> testData = new LinkedHashSet<>();
 
 
     /*============== Constructors ==============*/
@@ -214,7 +218,7 @@ public abstract class Sampler {
 
     /*============== methods for running tests  ==============*/
     
-    protected UnitTestResultSet testEmptyPatch(String targetClass, List<UnitTest> tests, SourceFile sourceFile) {
+    protected UnitTestResultSet testEmptyPatch(String targetClass, Collection<UnitTest> tests, SourceFile sourceFile) {
 
         Logger.debug("Testing the empty patch..");
 
@@ -223,9 +227,9 @@ public abstract class Sampler {
         UnitTestResultSet resultSet = null;
 
         if (!inSubprocess && !inNewSubprocess) {
-            resultSet = testPatchInternally(targetClass, tests, new Patch(sourceFile));
+            resultSet = testPatchInternally(targetClass, new ArrayList<>(tests), new Patch(sourceFile));
         } else {
-            resultSet = testPatchInSubprocess(targetClass, tests, new Patch(sourceFile));
+            resultSet = testPatchInSubprocess(targetClass, new ArrayList<>(tests), new Patch(sourceFile));
         }
 
         if (!resultSet.allTestsSuccessful()) {
@@ -365,9 +369,7 @@ public abstract class Sampler {
                     ginTest = UnitTest.fromString(test);
                     ginTest.setTimeoutMS(timeoutMS);
                     ginTests.add(ginTest);
-                    if (!testData.contains(ginTest)) {
-                        testData.add(ginTest);
-                    }
+                    testData.add(ginTest);
                 }
 
                 String method = data.get("Method");
@@ -477,7 +479,7 @@ public abstract class Sampler {
 
     protected void writeResults(UnitTestResultSet testResultSet, int patchCount, Integer methodID) {
         for (UnitTestResult result : testResultSet.getResults()) {
-            int testNameIdx = testData.indexOf(result.getTest()) + 1;
+            int testNameIdx = result.getTest().hashCode();
             writeResult(patchCount, testNameIdx, testResultSet.getPatch(), testResultSet.getValidPatch(), testResultSet.getCleanCompile(), result, methodID, testResultSet.getNoOp(), testResultSet.getEditsValid());
         }
     }


### PR DESCRIPTION
This is a performance improvement for the Method File reading procedure. This is related to issue #40.

I tried to read a method with 24k test cases, and it got stuck in the execution [of lines 368-370](https://github.com/gintool/gin/compare/master...GiovaniGuizzo:master#diff-18b6c6886a8c4daccd26318879b0f54dL368-L370)
This is the profiling result:

![image](https://user-images.githubusercontent.com/1986674/89767664-4e5ed500-daf2-11ea-8304-7c17c881b713.png)

The previous code would first check the existence of the test case before adding it to the list. When we have 24k test cases, the cost of such procedure becomes exponentially expensive.
With a LinkedHashSet, the complexity of adding a test case to the set is `O(1)`, while also keeping the insertion order.
Now the input of 24k test cases takes about a second.

All tests are passing.