### PR TITLE
Fixed a bug where Gin would throw a NullPointerException

### DIFF
--- a/src/main/java/gin/test/InternalTestRunner.java
+++ b/src/main/java/gin/test/InternalTestRunner.java
@@ -141,10 +141,13 @@ public class InternalTestRunner extends TestRunner {
         Object result = null;
         try {
             result = method.invoke(runner, test, rep);
-        } catch (IllegalAccessException e) {
+        } catch (IllegalAccessException | InvocationTargetException e) {
             Logger.trace(e);
-        } catch (InvocationTargetException e) {
-            Logger.trace(e);
+            UnitTestResult tempResult = new UnitTestResult(test, rep);
+            tempResult.setExceptionType(e.getClass().getName());
+            tempResult.setExceptionMessage(e.getMessage());
+            tempResult.setPassed(false);
+            result = tempResult;
         }
 
         int threadsAfter = getNumberOfThreads();


### PR DESCRIPTION
Gin would throw a NullPointerException when [trying to filter the list of UnitTestResults](https://github.com/gintool/gin/blob/master/src/main/java/gin/util/Sampler.java#L244) before outputting it, whilst the list contained a null value.

The bug occurred when Gin failed to access a member due to visibility [when trying to annotate the method with timeout](https://github.com/gintool/gin/blob/master/src/main/java/gin/test/JUnitBridge.java#L129). In this case, it would throw an exception, fallback to the changed code in this commit, and the result would be null.

Now it properly creates a failing result object and outputs it normally.
All tests are passing.