### PR TITLE
Fix for the "hanging threads" issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ examples/unittests/ExampleWithInnerClass.class
 examples/unittests/ExampleWithInnerClassTest.class
 /.classpath
 /.project
+nbproject/

--- a/src/main/java/gin/test/InternalTestRunner.java
+++ b/src/main/java/gin/test/InternalTestRunner.java
@@ -157,7 +157,7 @@ public class InternalTestRunner extends TestRunner {
         } finally {
             cleanupHangingThreads(threadsBefore);
         }
-        }
+    }
         
     private void cleanupHangingThreads(Set<Thread> threadsBefore) {
         Set<Thread> threadsAfter = Thread.getAllStackTraces().keySet();

--- a/src/main/java/gin/test/InternalTestRunner.java
+++ b/src/main/java/gin/test/InternalTestRunner.java
@@ -145,15 +145,15 @@ public class InternalTestRunner extends TestRunner {
         Set<Thread> threadsBefore = Thread.getAllStackTraces().keySet();
 
         try {
-            UnitTestResult res = (UnitTestResult) method.invoke(runner, test, rep);
-            return res;
+            UnitTestResult result = (UnitTestResult) method.invoke(runner, test, rep);
+            return result;
         } catch (IllegalAccessException | InvocationTargetException e) {
             Logger.trace(e);
-            UnitTestResult tempResult = new UnitTestResult(test, rep);
-            tempResult.setExceptionType(e.getClass().getName());
-            tempResult.setExceptionMessage(e.getMessage());
-            tempResult.setPassed(false);
-            return tempResult;
+            UnitTestResult result = new UnitTestResult(test, rep);
+            result.setExceptionType(e.getClass().getName());
+            result.setExceptionMessage(e.getMessage());
+            result.setPassed(false);
+            return result;
         } finally {
             cleanupHangingThreads(threadsBefore);
         }


### PR DESCRIPTION
This pull request fixes the "hanging threads" problem with the internal `JUnitRunner`. In my experiments, the threads with infinite loops would hang forever and keep executing (also consuming a single core each) even after timed out by JUnit.

With this fix, at the end of each test run, first the code checks for any existing Thread that was not there before executing the test, and then queues it up for interruption. I also added some debug logs (not outputted by default).

OBS: on my last PullRequest #47, I forgot to add another CacheClassLoader closing code in a super class. Here it is now.