### PR TITLE
Fix for the test poisoning "-jj"

### DIFF
--- a/examples/unittests/mypackage/Poison.java
+++ b/examples/unittests/mypackage/Poison.java
@@ -1,0 +1,21 @@
+package mypackage;
+
+import static org.junit.Assert.assertFalse;
+import org.junit.Test;
+
+/**
+ * Test class to test test poisoning over multiple repetitions.
+ *
+ * @author Giovani
+ */
+public class Poison {
+
+    public static boolean POISONED = false;
+
+    @Test
+    public void testPoison() {
+        assertFalse(POISONED);
+        POISONED = true;
+    }
+
+}

--- a/src/main/java/gin/util/Sampler.java
+++ b/src/main/java/gin/util/Sampler.java
@@ -29,7 +29,6 @@ import gin.test.UnitTestResultSet;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Handy class for mutating and running tests on mutated code.
@@ -78,10 +77,13 @@ public abstract class Sampler {
     protected Integer reps = 1;
 
     @Argument(alias = "j", description = "Run tests in a separate jvm")
-    protected Boolean inSubprocess = false;  
+    protected Boolean inSubprocess = false;
     
-    @Argument(alias = "J", description = "Run every test in a new jvm")
-    protected Boolean inNewSubprocess = false;  
+    @Argument(alias = "jj", description = "Run every repetition in a new jvm. Includes option '-j'")
+    protected Boolean eachRepetitionInNewSubprocess = false; 
+    
+    @Argument(alias = "J", description = "Run every test in a new jvm. Includes option '-j' and '-jj'")
+    protected Boolean eachTestInNewSubprocess = false;  
     
     // Unused at the moment, thus commented out
     //@Argument(alias = "b", description = "Buffer time for test cases to be run on modified code, set only if > -1 and when -inSubprocess is false")
@@ -226,7 +228,7 @@ public abstract class Sampler {
 
         UnitTestResultSet resultSet = null;
 
-        if (!inSubprocess && !inNewSubprocess) {
+        if (!inSubprocess && !eachRepetitionInNewSubprocess && !eachTestInNewSubprocess) {
             resultSet = testPatchInternally(targetClass, new ArrayList<>(tests), new Patch(sourceFile));
         } else {
             resultSet = testPatchInSubprocess(targetClass, new ArrayList<>(tests), new Patch(sourceFile));
@@ -282,7 +284,7 @@ public abstract class Sampler {
 
         UnitTestResultSet resultSet = null;
 
-        if (!inSubprocess && !inNewSubprocess) {
+        if (!inSubprocess && !eachTestInNewSubprocess) {
             resultSet = testPatchInternally(targetClass, tests, patch);
         } else {
             resultSet = testPatchInSubprocess(targetClass, tests, patch);
@@ -300,7 +302,7 @@ public abstract class Sampler {
 
     private UnitTestResultSet testPatchInSubprocess(String targetClass, List<UnitTest> tests, Patch patch) {
 
-        ExternalTestRunner testRunner = new ExternalTestRunner(targetClass, classPath, tests, inNewSubprocess);
+        ExternalTestRunner testRunner = new ExternalTestRunner(targetClass, classPath, tests, eachRepetitionInNewSubprocess, eachTestInNewSubprocess);
 
         UnitTestResultSet results = null;
 

--- a/src/main/java/gin/util/Sampler.java
+++ b/src/main/java/gin/util/Sampler.java
@@ -82,7 +82,7 @@ public abstract class Sampler {
     @Argument(alias = "jj", description = "Run every repetition in a new jvm. Includes option '-j'")
     protected Boolean eachRepetitionInNewSubprocess = false; 
     
-    @Argument(alias = "J", description = "Run every test in a new jvm. Includes option '-j' and '-jj'")
+    @Argument(alias = "J", description = "Run every test in a new jvm. Includes options '-j' and '-jj'")
     protected Boolean eachTestInNewSubprocess = false;  
     
     // Unused at the moment, thus commented out

--- a/src/test/java/gin/util/EmptyPatchTesterTest.java
+++ b/src/test/java/gin/util/EmptyPatchTesterTest.java
@@ -162,7 +162,7 @@ public class EmptyPatchTesterTest {
         sampler.classPath = resourcesDir.getPath();
         sampler.outputFile = outputFile;
         sampler.setUp();
-        sampler.inNewSubprocess = true;
+        sampler.eachTestInNewSubprocess = true;
 
         sampler.sampleMethods();
 


### PR DESCRIPTION
This is a fix for issue #53.

I added a new option in the Sampler to execute each repetition in a new subprocess.
I added a few tests too.

All tests are passing.