### PR TITLE
Added an option to inform hprof's interval

### DIFF
--- a/src/main/java/gin/util/Profiler.java
+++ b/src/main/java/gin/util/Profiler.java
@@ -7,7 +7,6 @@ import com.opencsv.CSVWriter;
 import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.sampullara.cli.Argument;
 import com.sampullara.cli.Args;
@@ -58,13 +57,14 @@ public class Profiler {
     @Argument(alias = "m", description="Maven mavenProfile to use, e.g. light-test")
     protected String mavenProfile = "";
 
-
+    @Argument(alias = "hi", description="Interval for hprof's CPU sampling in milliseconds")
+    protected Long hprofInterval = 10L;
 
     // Constants
 
     private static final String[] HEADER = {"Project", "MethodIndex", "Method", "Count", "Tests"};
     private static final String WORKING_DIR = "hprof";
-    private static final String HPROF_ARG = "-agentlib:hprof=cpu=samples,lineno=y,depth=1,file=";
+    private static String HPROF_ARG = "-agentlib:hprof=cpu=samples,lineno=y,depth=1,interval=$hprofInterval,file=";
 
     // Instance Members
     private File workingDir;
@@ -87,6 +87,8 @@ public class Profiler {
         if (this.mavenHome != null) {
             project.setMavenHome(this.mavenHome);
         }
+        // Adds the interval provided by the user
+        HPROF_ARG = HPROF_ARG.replace("$hprofInterval", Long.toString(hprofInterval));
     }
 
     // Main Profile Method


### PR DESCRIPTION
Added an option (`-hi`) to modify hprof's default CPU sampling interval, as suggested in #37. 