### PR TITLE
Fixing the patchValid check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ examples/unittests/ExampleWithInnerClassTest.class
 /.classpath
 /.project
 nbproject/
+.settings

--- a/src/main/java/gin/test/ExternalTestRunner.java
+++ b/src/main/java/gin/test/ExternalTestRunner.java
@@ -102,7 +102,7 @@ public class ExternalTestRunner extends TestRunner {
      * @return the results of the tests
      */
     public UnitTestResultSet runTests(Patch patch, int reps) throws IOException, InterruptedException {
-
+        
         createTempDirectory();
 
         // Apply the patch.
@@ -112,17 +112,22 @@ public class ExternalTestRunner extends TestRunner {
         
         // Did the code change as a result of applying the patch?
         boolean noOp = isPatchedSourceSame(patch.getSourceFile().toString(), patchedSource);
-
-        // Compile in temp dir
+        //Initialise with default value
         boolean compiledOK = false;
-        //if (patchValid) { // might be invalid due to a couple of edits, which drop to being no-ops; remaining edits might be ok so try compiling
-            compiledOK = compileClassToTempDir(patchedSource);
-        //}
-
-        // Run tests
         List<UnitTestResult> results;
-        if (compiledOK && patchValid) {
-            results = runTests(reps);
+        // Only tries to compile and run when the patch is valid
+        // The patch might be invalid due to a couple of edits, which
+        // drop to being no-ops; remaining edits might be ok so still
+        // try compiling and then running in case of no-op
+        if(patchValid) {
+            // Compile
+            compiledOK = compileClassToTempDir(patchedSource);
+            // Run tests
+            if (compiledOK) {
+                results = runTests(reps);
+            } else {
+                results = emptyResults(reps);
+            }
         } else {
             results = emptyResults(reps);
         }

--- a/src/main/java/gin/test/ExternalTestRunner.java
+++ b/src/main/java/gin/test/ExternalTestRunner.java
@@ -121,7 +121,7 @@ public class ExternalTestRunner extends TestRunner {
 
         // Run tests
         List<UnitTestResult> results;
-        if (compiledOK) {
+        if (compiledOK && patchValid) {
             results = runTests(reps);
         } else {
             results = emptyResults(reps);

--- a/src/main/java/gin/test/InternalTestRunner.java
+++ b/src/main/java/gin/test/InternalTestRunner.java
@@ -63,14 +63,12 @@ public class InternalTestRunner extends TestRunner {
             //}
             boolean compiledOK = (code != null);
 
-            // Add to class loader and run tests
-            List<UnitTestResult> results = null;
-            if (compiledOK) {
+            // Run tests
+            List<UnitTestResult> results;
+            if (compiledOK && patchValid) {
                 classLoader.setCustomCompiledCode(this.getClassName(), code.getByteCode());
                 results = runTests(reps, classLoader);
-            }
-
-            if (!patchValid || !compiledOK) {
+            } else {
                 results = emptyResults(reps);
             }
 


### PR DESCRIPTION
This fix is related to issue #54.

As agreed on our meeting:

1. The code is only compiled if the patch is valid;
2. If compiles ok, then the tests are run;
3. No-op is still run.

All tests are passing.