### PR TITLE
Fix equality of doubles

### DIFF
--- a/src/main/java/gin/util/GPFix.java
+++ b/src/main/java/gin/util/GPFix.java
@@ -17,26 +17,26 @@ import gin.test.UnitTestResultSet;
 
 /**
  * Method-based GPFix search.
- * Roughly based on: "A systematic study of automated program repair: Fixing 55 out of 105 bugs for $8 each." 
+ * Roughly based on: "A systematic study of automated program repair: Fixing 55 out of 105 bugs for $8 each."
  * by Claire Le Goues, Michael Dewey-Vogt, Stephanie Forrest, Westley Weimer (ICSE 2012)
- * and its Java implementation at https://github.com/squaresLab/genprog4java 
+ * and its Java implementation at https://github.com/squaresLab/genprog4java
  */
 
 public class GPFix extends GPSimple {
-   
+
     @Argument(alias = "rec", description = "Record all fitness values in a HashMap")
     protected Boolean record = false;
 
     public static void main(String[] args) {
         GPFix sampler = new GPFix(args);
         sampler.sampleMethods();
-    }   
+    }
 
     public GPFix(String[] args) {
         super(args);
         Args.parseOrExit(this, args);
         printAdditionalArguments();
-    }   
+    }
 
     private void printAdditionalArguments() {
         Logger.info("Record all fitness values in a HashMap: "+ record);
@@ -45,7 +45,7 @@ public class GPFix extends GPSimple {
     // Constructor used for testing
     public GPFix(File projectDir, File methodFile) {
         super(projectDir, methodFile);
-    }   
+    }
 
     // Arguments used in fitness calculation
     private static double weight = 2.0;
@@ -92,29 +92,29 @@ public class GPFix extends GPSimple {
                     fitness += this.multiplier;
                 }
             }
-        }   
+        }
         if (record) {
             recordedFitness.put(patch, fitness);
         }
-        if (fitness == this.targetFitness) {
+        if (Double.compare(fitness,this.targetFitness) == 0) {
             Logger.info("Found individual with target fitness: " + patch);
         }
         return fitness;
 
-    }   
+    }
 
     // Calculate fitness threshold, for selection to the next generation
     protected boolean fitnessThreshold(UnitTestResultSet results, double orig) {
 
         return fitness(results) > 0;
     }
-    
+
     // Compare two fitness values, newFitness better if result > 0
     protected double compareFitness(double newFitness, double oldFitness) {
-            
+
         return newFitness - oldFitness;
-    }       
-        
+    }
+
     /*============== Helper method  ==============*/
 
     // Set multiplier and test data for fitness calculations
@@ -141,5 +141,5 @@ public class GPFix extends GPSimple {
         Logger.info("Target fitness: " + this.targetFitness);
     }
 
-        
+
 } 


### PR DESCRIPTION
This operation compares two floating point values for equality. Because floating point calculations may involve rounding, calculated float and double values may not be accurate