### PR TITLE
Fail fast implemented.

### DIFF
--- a/src/main/java/gin/LocalSearch.java
+++ b/src/main/java/gin/LocalSearch.java
@@ -58,6 +58,11 @@ public class LocalSearch {
     
     /**allowed edit types for sampling: parsed from editType*/
     protected List<Class<? extends Edit>> editTypes;
+    
+    @Argument(alias = "ff", description = "Fail fast. "
+            + "If set to true, the tests will stop at the first failure and the next patch will be executed. "
+            + "You probably don't want to set this to true for Automatic Program Repair.")
+    protected Boolean failFast = false;
 
     protected SourceFile sourceFile;
     InternalTestRunner testRunner;
@@ -90,7 +95,7 @@ public class LocalSearch {
         if (this.testClassName == null) {
             this.testClassName = this.className + "Test";
         }
-        this.testRunner = new InternalTestRunner(className, classPath, testClassName);
+        this.testRunner = new InternalTestRunner(className, classPath, testClassName, failFast);
 
     }
 

--- a/src/main/java/gin/PatchAnalyser.java
+++ b/src/main/java/gin/PatchAnalyser.java
@@ -46,6 +46,11 @@ public class PatchAnalyser {
 
     @Argument(alias = "t", description = "Test class name")
     protected String testClassName;
+    
+    @Argument(alias = "ff", description = "Fail fast. "
+            + "If set to true, the tests will stop at the first failure and the next patch will be executed. "
+            + "You probably don't want to set this to true for Automatic Program Repair.")
+    protected Boolean failFast = false;
 
     private SourceFileLine sourceFileLine;
     private SourceFileTree sourceFileTree;
@@ -85,7 +90,7 @@ public class PatchAnalyser {
         SourceFileLine sourceFileLine = new SourceFileLine(source.getAbsolutePath(), null);
         SourceFileTree sourceFileTree = new SourceFileTree(source.getAbsolutePath(), null);
 
-        this.testRunner = new InternalTestRunner(className, classPath, testClassName);
+        this.testRunner = new InternalTestRunner(className, classPath, testClassName, failFast);
 
         // Dump statement numbering to a file
         String statementNumbering = sourceFileTree.statementList();

--- a/src/main/java/gin/util/Sampler.java
+++ b/src/main/java/gin/util/Sampler.java
@@ -85,6 +85,11 @@ public abstract class Sampler {
     @Argument(alias = "J", description = "Run every test in a new jvm. Includes options '-j' and '-jj'")
     protected Boolean eachTestInNewSubprocess = false;  
     
+    @Argument(alias = "ff", description = "Fail fast. "
+            + "If set to true, the tests will stop at the first failure and the next patch will be executed. "
+            + "You probably don't want to set this to true for Automatic Program Repair.")
+    protected Boolean failFast = false;
+    
     // Unused at the moment, thus commented out
     //@Argument(alias = "b", description = "Buffer time for test cases to be run on modified code, set only if > -1 and when -inSubprocess is false")
     //private Integer bufferTimeMS = -1;  // test case timeout: timeout on unmodified code + bufferTime
@@ -299,13 +304,13 @@ public abstract class Sampler {
 
     private UnitTestResultSet testPatchInternally(String targetClass, List<UnitTest> tests, Patch patch) {
 
-        InternalTestRunner testRunner = new InternalTestRunner(targetClass, classPath, tests);
+        InternalTestRunner testRunner = new InternalTestRunner(targetClass, classPath, tests, failFast);
         return testRunner.runTests(patch, reps);
     }
 
     private UnitTestResultSet testPatchInSubprocess(String targetClass, List<UnitTest> tests, Patch patch) {
 
-        ExternalTestRunner testRunner = new ExternalTestRunner(targetClass, classPath, tests, eachRepetitionInNewSubprocess, eachTestInNewSubprocess);
+        ExternalTestRunner testRunner = new ExternalTestRunner(targetClass, classPath, tests, eachRepetitionInNewSubprocess, eachTestInNewSubprocess, failFast);
 
         UnitTestResultSet results = null;
 


### PR DESCRIPTION
I created the Fail Fast functionality for gin.

Basically, by using the `-ff` option, now the test execution stops at the first failed test case.
This considerably improves execution time.

See #51 for more info.